### PR TITLE
修复Spine动画与立绘获取问题

### DIFF
--- a/src/ArknightsResources.Utility.csproj
+++ b/src/ArknightsResources.Utility.csproj
@@ -16,9 +16,9 @@
     <PackageIcon>icon.png</PackageIcon>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IsTrimmable>true</IsTrimmable>
-    <Version>0.1.6.0-alpha</Version>
-    <AssemblyVersion>0.1.6.0</AssemblyVersion>
-    <FileVersion>0.1.6.0</FileVersion>
+    <Version>0.1.7.0-alpha</Version>
+    <AssemblyVersion>0.1.7.0</AssemblyVersion>
+    <FileVersion>0.1.7.0</FileVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/ResourceHelper/OperatorResourceHelper.cs
+++ b/src/ResourceHelper/OperatorResourceHelper.cs
@@ -13,10 +13,13 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using System.Text.Unicode;
 using System.Threading.Tasks;
 using ArknightsResources.CustomResourceHelpers;
 using ArknightsResources.Operators.Models;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp;
 
 namespace ArknightsResources.Utility
 {

--- a/test/OperatorResourceHelperTest.cs
+++ b/test/OperatorResourceHelperTest.cs
@@ -38,29 +38,23 @@ namespace ArknightsResources.Utility.Test
         public async void GetOperatorSpineAnimationTest()
         {
             OperatorsList list = await OperatorResourceHelper.GetAllOperatorsAsync(ChineseSimplifiedCultureInfo);
-            //foreach (var pair in list.Operators)
-            //{
-            //    foreach (var illustInfo in pair.Value.Illustrations)
-            //    {
-            //        bool isSkin = illustInfo.Type == OperatorType.Skin;
-            //        string imageCodename = isSkin
-            //            ? illustInfo.ImageCodename
-            //            : pair.Value.Codename;
+            foreach (var pair in list.Operators)
+            {
+                foreach (var illustInfo in pair.Value.Illustrations)
+                {
+                    bool isSkin = illustInfo.Type == OperatorType.Skin;
+                    string imageCodename = isSkin
+                        ? illustInfo.ImageCodename
+                        : pair.Value.Codename;
 
-            //        OperatorSpineInfo spineInfo = new(OperatorSpineModelSet.Build, imageCodename, isSkin);
-            //        var value = OperatorResourceHelper.GetOperatorSpineAnimation(spineInfo);
+                    OperatorSpineInfo spineInfo = new(OperatorSpineModelSet.Build, imageCodename, isSkin);
+                    var value = OperatorResourceHelper.GetOperatorSpineAnimation(spineInfo);
 
-            //        Assert.NotNull(value.Item1);
-            //        Assert.NotNull(value.Item2);
-            //        Assert.NotEmpty(value.Item3);
-            //    }
-            //}
-            OperatorSpineInfo spineInfo = new(OperatorSpineModelSet.CombatFront, "elysm", false);
-            var value = OperatorResourceHelper.GetOperatorSpineAnimation(spineInfo);
-
-            Assert.NotNull(value.Item1);
-            Assert.NotNull(value.Item2);
-            Assert.NotEmpty(value.Item3);
+                    Assert.NotNull(value.Item1);
+                    Assert.NotNull(value.Item2);
+                    Assert.NotEmpty(value.Item3);
+                }
+            }
         }
 
         [Fact]
@@ -111,7 +105,7 @@ namespace ArknightsResources.Utility.Test
         }
 
         [Fact]
-        public void GetOperatorImageMappingTest()
+        public void GetOperatorCodenameMappingTest()
         {
             Dictionary<string, string> mapping = OperatorResourceHelper.GetOperatorCodenameMapping(ChineseSimplifiedCultureInfo);
             Assert.NotEmpty(mapping);

--- a/test/Usings.cs
+++ b/test/Usings.cs
@@ -1,3 +1,4 @@
 global using Xunit;
 global using ArknightsResources.Operators.Models;
 global using System.Globalization;
+global using System.Diagnostics;


### PR DESCRIPTION
<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮 -->

## 描述
修复一些Spine动画与立绘获取问题。
<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？
单包多Spine动画的情况下只能获取第一个动画
某些立绘不能获取(如缄默德克萨斯的精二立绘，包中含有立绘图像，但其Material文件指向的Texture2D文件的PathID为0)
<!-- 请描述应用在你修复之前的行为，或者添加 Issue 链接 -->

## 新的行为是什么？
单包多Spine动画的情况下会根据参数获取动画
先前不能获取的立绘能够获取了
<!-- 描述你解决了什么问题，现在的行为是什么 -->

## 备注
解决立绘获取问题的方法是：如果通过一般方法获取不到立绘，则会回退到以前版本的方法来获取(这可能会出错——不过概率不大)
<!-- 请添加任何你认为有帮助的信息 -->
<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->