### PR TITLE
将GetAllOperatorVoiceInfos方法移动到OperatorTextResourceHelper结构中

### DIFF
--- a/src/ArknightsResources.Utility.csproj
+++ b/src/ArknightsResources.Utility.csproj
@@ -16,9 +16,9 @@
     <PackageIcon>icon.png</PackageIcon>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IsTrimmable>true</IsTrimmable>
-    <Version>0.2.0.0-alpha</Version>
-    <AssemblyVersion>0.1.0.0</AssemblyVersion>
-    <FileVersion>0.2.0.0</FileVersion>
+    <Version>0.2.1.0-alpha</Version>
+    <AssemblyVersion>0.1.1.0</AssemblyVersion>
+    <FileVersion>0.2.1.0</FileVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/ResourceHelper/OperatorTextResourceHelper.cs
+++ b/src/ResourceHelper/OperatorTextResourceHelper.cs
@@ -293,6 +293,35 @@ namespace ArknightsResources.Utility
 #endif
             return operatorsDict;
         }
+
+        /// <summary>
+        /// 获取当前可用的全部语音信息
+        /// </summary>
+        /// <param name="cultureInfo"><see cref="OperatorVoiceInfo"/>对象所使用的语言</param>
+        /// <returns>一个Key为干员代号，Value为<see cref="OperatorVoiceInfo"/>数组的字典</returns>
+        public ImmutableDictionary<string, OperatorVoiceInfo[]> GetAllOperatorVoiceInfos(CultureInfo cultureInfo)
+        {
+            if (ResourceManager is null)
+            {
+                throw new InvalidOperationException($"此对象的属性 {nameof(ResourceManager)} 不可为空");
+            }
+
+            byte[] opVoices = (byte[])ResourceManager.GetObject("operator_voice_info", cultureInfo);
+            JsonSerializerOptions options = new JsonSerializerOptions()
+            {
+                WriteIndented = true,
+                Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
+                Converters = { new JsonStringEnumConverter() }
+            };
+#if NET6_0_OR_GREATER
+            //支持IL裁剪
+            StrOpVoiceInfoDictSourceGenerationContext context = new StrOpVoiceInfoDictSourceGenerationContext(options);
+            ImmutableDictionary<string, OperatorVoiceInfo[]> operatorsVoicesDict = JsonSerializer.Deserialize(opVoices, context.ImmutableDictionaryStringOperatorVoiceInfoArray);
+#else
+            ImmutableDictionary<string, OperatorVoiceInfo[]> operatorsVoicesDict = JsonSerializer.Deserialize<ImmutableDictionary<string, OperatorVoiceInfo[]>>(opVoices, options);
+#endif
+            return operatorsVoicesDict;
+        }
     }
 
 #if NET6_0_OR_GREATER
@@ -319,6 +348,12 @@ namespace ArknightsResources.Utility
     [JsonSourceGenerationOptions(WriteIndented = true)]
     [JsonSerializable(typeof(ImmutableDictionary<string, string[]>))]
     internal partial class ImmutableDictionaryStrStrArraySourceGenerationContext : JsonSerializerContext
+    {
+    }
+
+    [JsonSourceGenerationOptions(WriteIndented = true)]
+    [JsonSerializable(typeof(ImmutableDictionary<string, OperatorVoiceInfo[]>))]
+    internal partial class StrOpVoiceInfoDictSourceGenerationContext : JsonSerializerContext
     {
     }
 #endif

--- a/src/ResourceHelper/OperatorVoiceResourceHelper.cs
+++ b/src/ResourceHelper/OperatorVoiceResourceHelper.cs
@@ -102,44 +102,5 @@ namespace ArknightsResources.Utility
 
             return value;
         }
-
-        /// <summary>
-        /// 获取当前可用的全部语音信息
-        /// </summary>
-        /// <param name="cultureInfo"><see cref="OperatorVoiceInfo"/>对象所使用的语言</param>
-        /// <returns>一个Key为干员代号，Value为<see cref="OperatorVoiceInfo"/>数组的字典</returns>
-        public ImmutableDictionary<string, OperatorVoiceInfo[]> GetAllOperatorVoiceInfos(CultureInfo cultureInfo)
-        {
-            if (ResourceManager is null)
-            {
-                throw new InvalidOperationException($"此对象的属性 {nameof(ResourceManager)} 不可为空");
-            }
-
-            byte[] opVoices = (byte[])ResourceManager.GetObject("operator_voice_info", cultureInfo);
-            JsonSerializerOptions options = new JsonSerializerOptions()
-            {
-                WriteIndented = true,
-                Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
-                Converters = { new JsonStringEnumConverter() }
-            };
-#if NET6_0_OR_GREATER
-            //支持IL裁剪
-            StrOpVoiceInfoDictSourceGenerationContext context = new StrOpVoiceInfoDictSourceGenerationContext(options);
-            ImmutableDictionary<string, OperatorVoiceInfo[]> operatorsVoicesDict = JsonSerializer.Deserialize(opVoices, context.ImmutableDictionaryStringOperatorVoiceInfoArray);
-#else
-            ImmutableDictionary<string, OperatorVoiceInfo[]> operatorsVoicesDict = JsonSerializer.Deserialize<ImmutableDictionary<string, OperatorVoiceInfo[]>>(opVoices, options);
-#endif
-            return operatorsVoicesDict;
-        }
     }
-
-#if NET6_0_OR_GREATER
-    //这些类提供System.Text.Json源代码生成器的支持
-
-    [JsonSourceGenerationOptions(WriteIndented = true)]
-    [JsonSerializable(typeof(ImmutableDictionary<string, OperatorVoiceInfo[]>))]
-    internal partial class StrOpVoiceInfoDictSourceGenerationContext : JsonSerializerContext
-    {
-    }
-#endif
 }

--- a/test/OperatorResourceHelperTest.cs
+++ b/test/OperatorResourceHelperTest.cs
@@ -157,7 +157,7 @@ namespace ArknightsResources.Utility.Test
         [Fact]
         public void GetAllOperatorVoiceInfosTest()
         {
-            OperatorVoiceResourceHelper operatorResourceHelper = new(OperatorTextResources.ResourceManager);
+            OperatorTextResourceHelper operatorResourceHelper = new(OperatorTextResources.ResourceManager);
             ImmutableDictionary<string, OperatorVoiceInfo[]> mapping = operatorResourceHelper.GetAllOperatorVoiceInfos(AvailableCultureInfos.ChineseSimplifiedCultureInfo);
             Assert.NotEmpty(mapping);
         }


### PR DESCRIPTION
<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮 -->

## 描述
🚑️将GetAllOperatorVoiceInfos方法移动到OperatorTextResourceHelper结构中
🔖0.2.1.0
<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？
GetAllOperatorVoiceInfos方法错误地放置在OperatorVoiceHelper中
<!-- 请描述应用在你修复之前的行为，或者添加 Issue 链接 -->

## 新的行为是什么？
GetAllOperatorVoiceInfos方法移动到了OperatorTextResourceHelper中
<!-- 描述你解决了什么问题，现在的行为是什么 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->