### PR TITLE
修复 .NET Standard 2.0 目标无法编译的问题

### DIFF
--- a/src/ArknightsResources.Utility.csproj
+++ b/src/ArknightsResources.Utility.csproj
@@ -16,7 +16,7 @@
     <PackageIcon>icon.png</PackageIcon>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IsTrimmable>true</IsTrimmable>
-    <Version>0.2.5.0-alpha</Version>
+    <Version>0.2.6.0-alpha</Version>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/InternalNativeMemory.cs
+++ b/src/InternalNativeMemory.cs
@@ -1,4 +1,6 @@
-﻿namespace ArknightsResources.Utility
+﻿using System;
+
+namespace ArknightsResources.Utility
 {
     internal static unsafe class InternalNativeMemory
     {


### PR DESCRIPTION
<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮 -->

## 描述
🚨修复 .NET Standard 2.0 目标无法编译的问题
🔖0.2.6.0
<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？
.NET Standard 2.0 目标无法编译
<!-- 请描述应用在你修复之前的行为，或者添加 Issue 链接 -->

## 新的行为是什么？
补全了```src/InternalNativeMemory.cs```中缺失的```using System```语句，使.NET Standard 2.0 目标能够编译。
<!-- 描述你解决了什么问题，现在的行为是什么 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->